### PR TITLE
Add chat_confirm_delete to config

### DIFF
--- a/lua/parrot/config.lua
+++ b/lua/parrot/config.lua
@@ -52,6 +52,8 @@ local config = {
   chat_dir = vim.fn.stdpath("data"):gsub("/$", "") .. "/parrot/chats",
   -- chat user prompt prefix
   chat_user_prefix = "🗨:",
+  -- explicitly confirm deletion of a chat file
+  chat_confirm_delete = true,
   -- conceal model parameters in chat
   chat_conceal_model_params = true,
   -- local shortcuts bound to the chat buffer

--- a/lua/parrot/init.lua
+++ b/lua/parrot/init.lua
@@ -1022,6 +1022,13 @@ M.cmd.ChatDelete = function()
     return
   end
 
+  -- delete without confirmation
+  if not M.config.chat_confirm_delete then
+      futils.delete_file(file_name, M.config.chat_dir)
+      return
+  end
+
+  -- ask for confirmation
   vim.ui.input({ prompt = "Delete " .. file_name .. "? [y/N] " }, function(input)
     if input and input:lower() == "y" then
       futils.delete_file(file_name, M.config.chat_dir)


### PR DESCRIPTION
I usually don't delete my chats by accident, added `chat_confirm_delete` option to avoid confirmation.
It serves my purposes, but feel free to add.