### PR TITLE
Add entire_file templating value

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ The following commands are available within the chat files.
 
 ### Adding a new command
 
-WIP
-
 ```lua
 require("parrot").setup {
     -- ...
@@ -172,6 +170,50 @@ require("parrot").setup {
             parrot.logger.info("Asking agent: " .. agent.name)
             parrot.Prompt(params, parrot.ui.Target.popup, "🤖 Ask ~ ", agent.model, template, "", agent.provider)
       end,
+    }
+    -- ...
+}
+```
+
+### Utilizing Template Placeholders
+
+Users can utilize the following placeholders in their templates to inject
+specific content into the user messages:
+
+| Placeholder             | Content                              |
+|-------------------------|--------------------------------------|
+| `{{selection}}`         | Current visual selection             |
+| `{{filetype}}`          | Filetype of the current buffer       |
+| `{{filepath}}`          | Full path of the current file        |
+| `{{filecontent}}`       | Full content of the current buffer   |
+
+Below is an example of how to use these placeholders in a completion hook, which
+receives the full file context and the selected code snippet as input.
+
+
+```lua
+require("parrot").setup {
+    -- ...
+    hooks = {
+    	CompleteFullContext = function(prt, params)
+    	  local template = [[
+          I have the following code from {{filename}}:
+        
+          ```{{filetype}}
+          {{filecontent}}
+          ```
+          
+          Please look at the following section specifically:
+          ```{{filetype}}
+          {{selection}}
+          ```
+          
+          Please finish the code above carefully and logically.
+          Respond just with the snippet of code that should be inserted.
+          ]]
+    	  local agent = prt.get_command_agent()
+    	  prt.Prompt(params, prt.ui.Target.append, nil, agent.model, template, agent.system_prompt, agent.provider)
+    	end,
     }
     -- ...
 }

--- a/lua/parrot/init.lua
+++ b/lua/parrot/init.lua
@@ -1697,8 +1697,9 @@ M.Prompt = function(params, target, prompt, model, template, system_template, ag
     local messages = {}
     local filetype = pft.detect(vim.api.nvim_buf_get_name(buf))
     local filename = vim.api.nvim_buf_get_name(buf)
+    local entire_file = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
 
-    local sys_prompt = utils.template_render(system_template, command, selection, filetype, filename)
+    local sys_prompt = utils.template_render(system_template, command, selection, filetype, filename, entire_file)
     sys_prompt = sys_prompt or ""
     local prov = M.get_provider()
     if prov.name ~= agent_provider then
@@ -1712,7 +1713,7 @@ M.Prompt = function(params, target, prompt, model, template, system_template, ag
       table.insert(messages, { role = "system", content = repo_instructions })
     end
 
-    local user_prompt = utils.template_render(template, command, selection, filetype, filename)
+    local user_prompt = utils.template_render(template, command, selection, filetype, filename, entire_file)
     table.insert(messages, { role = "user", content = user_prompt })
 
     -- cancel possible visual mode before calling the model

--- a/lua/parrot/init.lua
+++ b/lua/parrot/init.lua
@@ -1637,9 +1637,7 @@ M.Prompt = function(params, target, prompt, model, template, system_template, ag
     local messages = {}
     local filetype = pft.detect(vim.api.nvim_buf_get_name(buf))
     local filename = vim.api.nvim_buf_get_name(buf)
-    local entire_file = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
-
-    local sys_prompt = utils.template_render(system_template, command, selection, filetype, filename, entire_file)
+    local sys_prompt = utils.template_render(system_template, command, selection, filetype, filename)
     sys_prompt = sys_prompt or ""
     local prov = M.get_provider()
     if prov.name ~= agent_provider then
@@ -1653,7 +1651,8 @@ M.Prompt = function(params, target, prompt, model, template, system_template, ag
       table.insert(messages, { role = "system", content = repo_instructions })
     end
 
-    local user_prompt = utils.template_render(template, command, selection, filetype, filename, entire_file)
+    local filecontent = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
+    local user_prompt = utils.template_render(template, command, selection, filetype, filename, filecontent)
     table.insert(messages, { role = "user", content = user_prompt })
 
     -- cancel possible visual mode before calling the model

--- a/lua/parrot/utils.lua
+++ b/lua/parrot/utils.lua
@@ -202,13 +202,14 @@ M.template_render_from_list = function(template, key_value_pairs)
   return template
 end
 
-M.template_render = function(template, command, selection, filetype, filename, entire_file)
+M.template_render = function(template, command, selection, filetype, filename, filecontent)
+  filecontent = filecontent or ""
   local key_value_pairs = {
     ["{{command}}"] = command,
     ["{{selection}}"] = selection,
     ["{{filetype}}"] = filetype,
     ["{{filename}}"] = filename,
-    ["{{entire_file}}"] = entire_file,
+    ["{{filecontent}}"] = filecontent,
   }
   return M.template_render_from_list(template, key_value_pairs)
 end
@@ -277,11 +278,11 @@ M.append_selection = function(params, origin_buf, target_buf, template_selection
   -- prepare selection
   local lines = vim.api.nvim_buf_get_lines(origin_buf, params.line1 - 1, params.line2, false)
   local selection = table.concat(lines, "\n")
-  local entire_file = table.concat(vim.api.nvim_buf_get_lines(origin_buf, 0, -1, false), "\n")
   if selection ~= "" then
     local filetype = pft.detect(vim.api.nvim_buf_get_name(origin_buf))
     local fname = vim.api.nvim_buf_get_name(origin_buf)
-    local rendered = M.template_render(template_selection, "", selection, filetype, fname, entire_file)
+    local filecontent = table.concat(vim.api.nvim_buf_get_lines(origin_buf, 0, -1, false), "\n")
+    local rendered = M.template_render(template_selection, "", selection, filetype, fname, filecontent)
     if rendered then
       selection = rendered
     end

--- a/lua/parrot/utils.lua
+++ b/lua/parrot/utils.lua
@@ -137,7 +137,7 @@ end
 ---@param str string # string to check
 ---@param ending string # string to check for
 M.ends_with = function(str, ending)
-  return ending == "" or str:sub(- #ending) == ending
+  return ending == "" or str:sub(-#ending) == ending
 end
 
 ---@param file_name string # name of the file for which to get buffer

--- a/lua/parrot/utils.lua
+++ b/lua/parrot/utils.lua
@@ -137,7 +137,7 @@ end
 ---@param str string # string to check
 ---@param ending string # string to check for
 M.ends_with = function(str, ending)
-  return ending == "" or str:sub(-#ending) == ending
+  return ending == "" or str:sub(- #ending) == ending
 end
 
 ---@param file_name string # name of the file for which to get buffer
@@ -202,12 +202,13 @@ M.template_render_from_list = function(template, key_value_pairs)
   return template
 end
 
-M.template_render = function(template, command, selection, filetype, filename)
+M.template_render = function(template, command, selection, filetype, filename, entire_file)
   local key_value_pairs = {
     ["{{command}}"] = command,
     ["{{selection}}"] = selection,
     ["{{filetype}}"] = filetype,
     ["{{filename}}"] = filename,
+    ["{{entire_file}}"] = entire_file,
   }
   return M.template_render_from_list(template, key_value_pairs)
 end
@@ -279,10 +280,11 @@ M.append_selection = function(params, origin_buf, target_buf, template_selection
   -- prepare selection
   local lines = vim.api.nvim_buf_get_lines(origin_buf, params.line1 - 1, params.line2, false)
   local selection = table.concat(lines, "\n")
+  local entire_file = table.concat(vim.api.nvim_buf_get_lines(origin_buf, 0, -1, false), "\n")
   if selection ~= "" then
     local filetype = pft.detect(vim.api.nvim_buf_get_name(origin_buf))
     local fname = vim.api.nvim_buf_get_name(origin_buf)
-    local rendered = M.template_render(template_selection, "", selection, filetype, fname)
+    local rendered = M.template_render(template_selection, "", selection, filetype, fname, entire_file)
     if rendered then
       selection = rendered
     end


### PR DESCRIPTION
It'd be helpful in a lot of cases for the LLM to get the context of the whole file for completions/replacements. This PR adds an `{{entire_file}}` value that can be used in a template.

Example prompt I have it working with:
```
            I have the following code from {{filename}}:

            ```{{filetype}}
            {{entire_file}}
            ```

            Please look at the following section specifically:

            ```{{filetype}}
            {{selection}}
            ```

            Please rewrite just that section according to the contained instructions.
            Respond exclusively with the snippet that should replace that section.
            Please consider indentation level.
            DO NOT RETURN ANY EXPLANATION OR COMMENTS, ONLY RETURN CODE.
            DO NOT WRAP CODE IN BACKTICKS.
```