### PR TITLE
fix: PrtChatRespond looking at incorrect path with symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ The following commands are available within the chat files.
     },
 
     -- The directory to store the chats (searched with PrtChatFinder)
-    chat_dir = vim.loop.fs_realpath(vim.fn.stdpath("data"):gsub("/$", "") .. "/parrot/chats",),
-
+    chat_dir = vim.loop.fs_realpath(vim.fn.stdpath("data"):gsub("/$", "") .. "/parrot/chats"),
     -- Chat user prompt prefix
     chat_user_prefix = "🗨:",
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The following commands are available within the chat files.
     },
 
     -- The directory to store the chats (searched with PrtChatFinder)
-    chat_dir = vim.fn.stdpath("data"):gsub("/$", "") .. "/parrot/chats",
+    chat_dir = vim.loop.fs_realpath(vim.fn.stdpath("data"):gsub("/$", "") .. "/parrot/chats",),
 
     -- Chat user prompt prefix
     chat_user_prefix = "🗨:",

--- a/lua/parrot/config.lua
+++ b/lua/parrot/config.lua
@@ -58,7 +58,7 @@ local config = {
     chat = agents.chat_agents,
     command = agents.command_agents,
   },
-  chat_dir = vim.fn.stdpath("data"):gsub("/$", "") .. "/parrot/chats",
+  chat_dir = vim.loop.fs_realpath(vim.fn.stdpath("data"):gsub("/$", "") .. "/parrot/chats"),
   chat_user_prefix = "🗨:",
   chat_confirm_delete = true,
   chat_shortcut_respond = { modes = { "n", "i", "v", "x" }, shortcut = "<C-g><C-g>" },


### PR DESCRIPTION
Using `vim.loop.fs_realpath` to determine the symlinked path.

Fix: #32