### PR TITLE
Feature: add template placeholder to add content of all open files

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ specific content into the user messages:
 | `{{filetype}}`          | Filetype of the current buffer       |
 | `{{filepath}}`          | Full path of the current file        |
 | `{{filecontent}}`       | Full content of the current buffer   |
+| `{{multifilecontent}}`  | Full content of all open buffers     |
 
 Below is an example of how to use these placeholders in a completion hook, which
 receives the full file context and the selected code snippet as input.

--- a/lua/parrot/config.lua
+++ b/lua/parrot/config.lua
@@ -92,6 +92,11 @@ local config = {
   template_selection = [[
 	I have the following content from {{filename}}:
 
+  Here is the full context:
+	```{{filetype}}
+	{{multifilecontent}}
+	```
+
 	```{{filetype}}
 	{{selection}}
 	```

--- a/lua/parrot/init.lua
+++ b/lua/parrot/init.lua
@@ -1551,7 +1551,8 @@ M.Prompt = function(params, target, agent, prompt, template)
     end
 
     local filecontent = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
-    local user_prompt = utils.template_render(template, command, selection, filetype, filename, filecontent)
+    local multifilecontent = utils.get_all_buffer_content()
+    local user_prompt = utils.template_render(template, command, selection, filetype, filename, filecontent, multifilecontent)
     table.insert(messages, { role = "user", content = user_prompt })
 
     -- cancel possible visual mode before calling the model

--- a/lua/parrot/init.lua
+++ b/lua/parrot/init.lua
@@ -1552,7 +1552,8 @@ M.Prompt = function(params, target, agent, prompt, template)
 
     local filecontent = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
     local multifilecontent = utils.get_all_buffer_content()
-    local user_prompt = utils.template_render(template, command, selection, filetype, filename, filecontent, multifilecontent)
+    local user_prompt =
+      utils.template_render(template, command, selection, filetype, filename, filecontent, multifilecontent)
     table.insert(messages, { role = "user", content = user_prompt })
 
     -- cancel possible visual mode before calling the model

--- a/lua/parrot/utils.lua
+++ b/lua/parrot/utils.lua
@@ -201,7 +201,6 @@ M.template_render_from_list = function(template, key_value_pairs)
 end
 
 M.template_render = function(template, command, selection, filetype, filename, filecontent, multifilecontent)
-  -- filecontent = filecontent or ""
   local key_value_pairs = {
     ["{{command}}"] = command,
     ["{{selection}}"] = selection,
@@ -281,39 +280,6 @@ M.get_all_buffer_content = function()
 
   return table.concat(content, "\n\n")
 end
-
--- M.get_all_buffer_content = function()
---   local fzf_lua = require("fzf-lua")
--- 	local selected_buffers = {}
--- 	fzf_lua.buffers({
---     fzf_opts = {
---       ["--multi"] = "", -- Enable multi-select
---     },
---     actions = {
---       ["default"] = function(selected)
---         if not selected or #selected == 0 then
---           return ""
---         end
---         for _, item in ipairs(selected) do
---           local buf_id = tonumber(item:match("(%d+)"))
---           if buf_id then
---             local lines = table.concat(vim.api.nvim_buf_get_lines(buf_id, 0, -1, false), "\n")
---             table.insert(selected_buffers, lines)
---           end
---         end
--- 				print("SELECTE", vim.inspect(table.concat(selected_buffers, "\n")))
--- 				return table.concat(selected_buffers, "\n")
---       end
---     },
---     previewer = "builtin",
---     winopts = {
---       height = 0.5,
---       width = 0.5,
---       row = 0.35,
---       col = 0.5,
---     },
---   })
--- end
 
 ---@param params table # table with command args
 ---@param origin_buf number # selection origin buffer


### PR DESCRIPTION
This branch implements the feature to include the content of all open buffers in templates using the placeholder ``{{multifileconent}}``.

An example would be the following hook:

```lua
CompleteMultiContext = function(prt, params)
  local template = [[
    I have the following code from {{filename}} and other realted files:

      ```{{filetype}}
      {{multifilecontent}}
      ```

      Please look at the following section specifically:
      ```{{filetype}}
      {{selection}}
      ```

      Please finish the code above carefully and logically.
      Respond just with the snippet of code that should be inserted."
    ]]
    local agent = prt.get_command_agent()
    prt.Prompt(params, prt.ui.Target.append, agent, nil, template)
end
```

A pending feature included in this branch is the option to select buffers via fzf-lua.