### PR TITLE
Implement command to retry rewrite, append or prepend command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ Let the parrot fix your bugs.
 </div>
 </details>
 
+<details>
+<summary>Retry your latest rewrite, append or prepend with `PrtRetry`.</summary>
+<div align="left">
+    <img src="https://github.com/user-attachments/assets/a46f5c95-10fc-492d-a1d9-4e794b43599d" width="100%">
+</div>
+</details>
+
 ## Getting Started
 
 ### Dependencies
@@ -165,6 +172,7 @@ Additional useful commands are implemented through hooks (see my example configu
 | `PrtEnew`                 | Prompt the model to respond in a new buffer   |
 | `PrtVnew`                 | Prompt the model to respond in a vsplit       |
 | `PrtTabnew`               | Prompt the model to respond in a new tab      |
+| `PrtRetry`                | Repeats the last rewrite/append/prepend       |
 |  __Example Hooks__        | |
 | `PrtImplement`            | takes the visual selection as prompt to generate code |
 | `PrtAsk`                  | Ask the model a question                      |

--- a/lua/parrot/chat_handler.lua
+++ b/lua/parrot/chat_handler.lua
@@ -1034,7 +1034,6 @@ function ChatHandler:retry(params)
   params.range = 2
   local model_obj = self:get_model("command")
   local template = ""
-  -- rewrite needs custom template
   if self.history.last_target == ui.Target.rewrite then
     template = self.options.template_rewrite
   elseif self.history.last_target == ui.Target.append then

--- a/lua/parrot/config.lua
+++ b/lua/parrot/config.lua
@@ -349,7 +349,7 @@ function M.setup(opts)
     Context = "context",
     Model = "model",
     Provider = "provider",
-    Regenerate = "regenerate",
+    Retry = "retry",
   }
 
   M.chat_handler = ChatHandler:new(M.options, M.providers, M.available_providers, available_models, M.cmd)

--- a/lua/parrot/config.lua
+++ b/lua/parrot/config.lua
@@ -349,6 +349,7 @@ function M.setup(opts)
     Context = "context",
     Model = "model",
     Provider = "provider",
+    Regenerate = "regenerate",
   }
 
   M.chat_handler = ChatHandler:new(M.options, M.providers, M.available_providers, available_models, M.cmd)


### PR DESCRIPTION
This pull request implements the `PrtRetry` feature, which allows you to retry your most recent `PrtRewrite`, `PrtAppend`, or `PrtPrepend` command using the initial code selection and prompt. For further details, see the example in the README.