### PR TITLE
fixed infinite loop freeze caused by the way paths are handled on Windows

### DIFF
--- a/lua/parrot/file_utils.lua
+++ b/lua/parrot/file_utils.lua
@@ -58,13 +58,15 @@ end
 ---@return string # returns the path of the git root dir or an empty string if not found
 M.find_git_root = function()
   local cwd = vim.fn.expand("%:p:h")
-  local git_dir = cwd .. "/.git"
-  while cwd ~= "/" do
-    if vim.fn.isdirectory(git_dir) == 1 then
+  while cwd ~= "" do
+    if vim.fn.isdirectory(cwd .. "/.git") == 1 then
       return cwd
     end
-    cwd = vim.fn.fnamemodify(cwd, ":h")
-    git_dir = cwd .. "/.git"
+    local parent = vim.fn.fnamemodify(cwd, ":h")
+    if parent == cwd then
+      break
+    end
+    cwd = parent
   end
   return ""
 end


### PR DESCRIPTION
 On Windows, the root directory is usually a drive letter like C:\, not just /. Therefore, when you keep modifying cwd with :h (which moves up one directory), you might never reach a condition that exits the loop correctly, particularly if the directory structure isn't what the code expects. This change will traverse to parent until no change (break condition) and should make the code more safe and portable. 