### PR TITLE
fix: Set filetype to markdown for parrot responses

### DIFF
--- a/lua/parrot/chat_handler.lua
+++ b/lua/parrot/chat_handler.lua
@@ -1395,8 +1395,7 @@ function ChatHandler:prompt(params, target, model_obj, prompt, template, reset_h
         end,
       })
 
-      local ft = target.filetype or filetype
-      vim.api.nvim_set_option_value("filetype", ft, { buf = buf })
+      vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf })
 
       handler = ResponseHandler:new(self.queries, buf, win, 0, false, "", cursor):create_handler()
     end


### PR DESCRIPTION
Set the filetype to markdown for parrot responses instead of using the target filetype. This ensures that the filetype is consistent for all parrot responses.