### PR TITLE
fix: change current_provider default value to nil

### DIFF
--- a/lua/parrot/state.lua
+++ b/lua/parrot/state.lua
@@ -21,14 +21,14 @@ function State:init_file_state(available_providers)
       self.file_state[prov] = { chat_model = nil, command_model = nil }
     end
   end
-  self.file_state.current_provider = self.file_state.current_provider or { chat = "", command = "" }
+  self.file_state.current_provider = self.file_state.current_provider or { chat = nil, command = nil }
 end
 
 --- Initializes state for a specific provider if it's not already initialized.
 --- @param available_providers table
 --- @param available_models table
 function State:init_state(available_providers, available_models)
-  self._state.current_provider = self._state.current_provider or { chat = "", command = "" }
+  self._state.current_provider = self._state.current_provider or { chat = nil, command = nil }
   for _, provider in ipairs(available_providers) do
     self._state[provider] = self._state[provider] or { chat_model = nil, command_model = nil }
     self:load_models(provider, "chat_model", available_models)

--- a/tests/parrot/state_spec.lua
+++ b/tests/parrot/state_spec.lua
@@ -100,8 +100,8 @@ describe("State", function()
 
         assert.are.same({
           current_provider = {
-            chat = "",
-            command = "",
+            chat = nil,
+            command = nil,
           },
           mistral = {
             chat_model = "model3",
@@ -122,7 +122,7 @@ describe("State", function()
         local state = State:new("/tmp")
         state:init_state({ "ollama" }, { ollama = { "model1", "model2" } })
         assert.are.same({
-          current_provider = { chat = "", command = "" },
+          current_provider = { chat = nil, command = nil },
           ollama = { chat_model = "model1", command_model = "model1" },
         }, state._state)
       end)
@@ -220,7 +220,7 @@ describe("State", function()
         state:init_state({ "openai" }, { openai = { "gpt-4o", "gpt-3.5" } })
         state:set_provider("openai", true)
         assert.are.same("openai", state._state.current_provider.chat)
-        assert.are.same("", state._state.current_provider.command)
+        assert.are.same(nil, state._state.current_provider.command)
 
         state:set_provider("groq", false)
         assert.are.same("groq", state._state.current_provider.command)


### PR DESCRIPTION
The PR is based on issue https://github.com/frankroeder/parrot.nvim/issues/87
The main cause of #87 is because current_provider in state.lua is initial as `{ chat = "", command = ""}`, when `chat_handler.lua` `ChatHandler:get_provider` first time been called, `current_prov` will be nil so it will try to get `prov` by called `State:get_provider`, but it will return "" by `self.file_state.current_provider.chat` (or  `self.file_state.current_provider.command`) because the `file_state` hasn't updated yet.
And since empty string is truthy, so `chat_handler.lua:78` (`if not prov`) will be false, then finally lead to query a provider with empty string.

One of the solutions I came up with was to simply set `current_provider` to `{ chat = nil, command = nil }` when init states.