### PR TITLE
fix(perplexity): update available models

### DIFF
--- a/lua/parrot/config.lua
+++ b/lua/parrot/config.lua
@@ -40,7 +40,7 @@ local defaults = {
       endpoint = "https://api.perplexity.ai/chat/completions",
       topic_prompt = topic_prompt,
       topic = {
-        model = "llama-3.1-sonar-small-128k-online",
+        model = "sonar",
         params = { max_tokens = 64 },
       },
       params = {

--- a/lua/parrot/provider/perplexity.lua
+++ b/lua/parrot/provider/perplexity.lua
@@ -118,9 +118,11 @@ end
 ---@return string[]
 function Perplexity:get_available_models()
   return {
-    "llama-3.1-sonar-small-128k-online",
-    "llama-3.1-sonar-large-128k-online",
-    "llama-3.1-sonar-huge-128k-online",
+    "llama-3.1-sonar-small-128k-online", -- deprecated, will stop working after 2025-02-22
+    "llama-3.1-sonar-large-128k-online", -- deprecated, will stop working after 2025-02-22
+    "llama-3.1-sonar-huge-128k-online",  -- deprecated, will stop working after 2025-02-22
+    "sonar",
+    "sonar-pro",
   }
 end
 


### PR DESCRIPTION
The Llama 3.1 models are deprecated now: https://docs.perplexity.ai/guides/model-cards.

New models for Perplexity going forward are `sonar` and `sonar-pro`.