### PR TITLE
fix(perplexity): add the new reasoning pro model

### DIFF
--- a/lua/parrot/provider/perplexity.lua
+++ b/lua/parrot/provider/perplexity.lua
@@ -124,6 +124,7 @@ function Perplexity:get_available_models()
     "sonar",
     "sonar-pro",
     "sonar-reasoning",
+    "sonar-reasoning-pro",
   }
 end
 


### PR DESCRIPTION
There is now a pro version of the reasoning model: https://docs.perplexity.ai/guides/model-cards