### PR TITLE
Fixes an error message about replacement string containing newlines

### DIFF
--- a/lua/parrot/provider/anthropic.lua
+++ b/lua/parrot/provider/anthropic.lua
@@ -127,7 +127,8 @@ function Anthropic:notify_thinking(thinking)
 
     -- Accumulate tokens into one coherent string.
     self._thinking_output = self._thinking_output .. thinking
-    vim.api.nvim_buf_set_lines(self._thinking_buf, 0, -1, false, { self._thinking_output })
+    local lines = vim.split(self._thinking_output, "\n", {})
+    vim.api.nvim_buf_set_lines(self._thinking_buf, 0, -1, false, lines)
   end)
 end
 


### PR DESCRIPTION
Previously I've been getting the following error message when the thinking output contained newlines:
`Error executing vim.schedule lua callback: ...im/plugged/parrot.nvim/lua/parrot/provider/anthropic.
lua:130: 'replacement string' item contains newlines
stack traceback:
        [C]: in function 'nvim_buf_set_lines'
        ...im/plugged/parrot.nvim/lua/parrot/provider/anthropic.lua:130: in function <...im/plugged
/parrot.nvim/lua/parrot/provider/anthropic.lua:107>
`