### PR TITLE
fix: pass payload to curl through stdin

### DIFF
--- a/lua/parrot/chat_handler.lua
+++ b/lua/parrot/chat_handler.lua
@@ -1651,7 +1651,7 @@ function ChatHandler:query(buf, provider, payload, handler, on_exit)
     "-H",
     "content-type: application/json",
     "-d",
-    vim.json.encode(payload),
+    "@-",
   }
 
   for _, arg in ipairs(args) do
@@ -1665,6 +1665,7 @@ function ChatHandler:query(buf, provider, payload, handler, on_exit)
   local job = Job:new({
     command = "curl",
     args = curl_params,
+    writer = vim.json.encode(payload),
     on_exit = function(response, exit_code)
       logger.debug("on_exit: " .. vim.inspect(response:result()))
       if exit_code ~= 0 then


### PR DESCRIPTION
hey hey

I've encountered an issue when trying to pass very very big payloads and it seems like it's because the payload is passed to curl via arguments

passing the payload through stdin seems to work fine

do you see any issues with this approach?
an obvious one is not seeing the payload when debugging and checking the curl command called