### PR TITLE
chore(openai): add o4-mini

### DIFF
--- a/lua/parrot/provider/openai.lua
+++ b/lua/parrot/provider/openai.lua
@@ -169,6 +169,7 @@ function OpenAI:get_available_models(online)
     "gpt-4.1-nano-2025-04-14",
     "o3-mini-2025-01-31",
     "o3-mini",
+    "o4-mini",
     "gpt-4",
     "gpt-4-0125-preview",
     "gpt-4-turbo-preview",


### PR DESCRIPTION
Add the o4-mini model to selection menu (the payload for API call has already been updated, but the model was not added before).