### PR TITLE
docs: add Perplexity setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,41 @@ providers = {
 ```
 </details>
 
+<details>
+<summary>Perplexity</summary>
+
+```lua
+proviers = {
+  perplexity = {
+    name = "perplexity",
+    api_key = os.getenv("PERPLEXITY_API_KEY"),
+    endpoint = "https://api.perplexity.ai/chat/completions",
+    headers = function(self)
+      return {
+        ["Content-Type"] = "application/json",
+        ["Accept"] = "application/json",
+        ["Authorization"] = "Bearer " .. self.api_key,
+      }
+    end,
+    topic = {
+      model = "r1-1776",
+      params = {
+        max_tokens = 64,
+      },
+    },
+    models = {
+      "sonar",
+      "sonar-pro",
+      "sonar-deep-research",
+      "sonar-reasoning",
+      "sonar-reasoning-pro",
+      "r1-1776",
+    },
+  }
+}
+```
+</details>
+
 ### Adding a new command
 
 #### Ask a single-turn question and receive the answer in a popup window


### PR DESCRIPTION
Perplexity setup example. [See their docs](https://docs.perplexity.ai/guides/getting-started). Tested with the `sonar` model.

Summarization of chats does not seem to work, output is always `<think>`. But otherwise, works fine.