### PR TITLE
Submit on Enter

### DIFF
--- a/lua/parrot/chat_utils.lua
+++ b/lua/parrot/chat_utils.lua
@@ -26,6 +26,7 @@ M.prep_md = function(buf)
   vim.api.nvim_command("setlocal wrap linebreak")
   -- auto save on TextChanged, InsertLeave
   vim.api.nvim_command("autocmd TextChanged,InsertLeave <buffer=" .. buf .. "> silent! write")
+  vim.api.nvim_command("nnoremap <buffer> <CR> :PrtChatResponde<CR>")
 
   -- register shortcuts local to this buffer
   buf = buf or vim.api.nvim_get_current_buf()


### PR DESCRIPTION
Currently parrot requires a custom mapping for PrtChatResponde/Submit.
I find the Enter key to be more intuitive as it is the key usually used in chat software.

I saws this in https://github.com/DanBradbury/copilot-chat.vim/blob/7d3a7515face04929e148db592e7d1cc96a65b99/ftplugin/copilot_chat.vim#L8.

This is merely a suggestion, I can obviously modify it if need be.
Maybe this should be wrapped in an [if !hasmapto()](https://github.com/diepfote/vim-checkbox/blob/5ef2172f07a3aaf82cabf8540d2eef6de6225242/plugin/checkbox.vim#L87).
But I am unsure as to whether this is handled elsewhere (and in lua).

Cheers
