### PR TITLE
fix(providers): use provider-specific curl parameters on fetch models

### DIFF
--- a/lua/parrot/provider/multi_provider.lua
+++ b/lua/parrot/provider/multi_provider.lua
@@ -456,6 +456,10 @@ function MultiProvider:get_available_models()
       args = type(self.model_endpoint) == "table" and self.model_endpoint or { self.model_endpoint }
     end
 
+    for _, param in ipairs(self._curl_params) do
+      table.insert(args, param)
+    end
+
     -- Add headers to args
     for k, v in pairs(hdrs) do
       table.insert(args, "-H")


### PR DESCRIPTION
Hello! I noticed while updating the available models cache that curl_params weren't being pulled in and the request was returning an error (I use -k and --noproxy). I found the spot, tried updating the models cache, and now everything's okay. I apologize for misleading you yesterday by writing that yesterday's PR was working; I didn't consider that the list of models was cached after previous experiments.