### PR TITLE
fix(chat_finder): make rg pattern quoting Windows-compatible

### DIFF
--- a/lua/parrot/chat_handler.lua
+++ b/lua/parrot/chat_handler.lua
@@ -1085,7 +1085,7 @@ function ChatHandler:chat_finder()
       actions["default"] = actions["ctrl-t"]
     end
 
-    fzf_lua.fzf_exec("rg --no-heading '# topic:' --type=md --sortr=accessed", {
+    fzf_lua.fzf_exec('rg --no-heading "# topic:" --type=md --sortr=accessed', {
       cwd = self.options.chat_dir,
       prompt = "Chat selection ❯",
       fzf_opts = self.options.fzf_lua_opts,


### PR DESCRIPTION
On Windows, :PrtChatFinder can show an empty picker even when chat files exist.

The fzf-lua integration runs:

rg --no-heading '# topic:' --type=md --sortr=accessed

On Windows, cmd.exe does not treat single quotes ('...') as string delimiters. As a result, rg receives an invalid pattern and returns no output. Linux/macOS work correctly, so this issue only appears on Windows.

Switching to double quotes fixes :PrtChatFinder on Windows without affecting Linux/macOS behavior. This should cause no behavioral changes beyond fixing Windows compatibility.